### PR TITLE
Add ignoredPaths setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This extension contributes the following settings:
 - `workspace-default-settings.runOnActivation`: Whether the plugin will automatically synchronize the settings on activation. Default: `true`.
 - `workspace-default-settings.jsonIndentation`: Number of columns for JSON indentation when saving the settings. Default: `2`.
 - `workspace-default-settings.defaultSettingsFileName`: Name of file that contains the default workspace settings. Default: `settings.default.json`.
+- `workspace-default-settings.ignoredPaths`: Allows users to locally ignore synchronization on certain properties. Default: `[]`. Example: `["editor.rulers"]`.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,15 @@
           "type": "string",
           "default": "settings.default.json",
           "description": "Name of file that contains the default workspace settings."
+        },
+        "workspace-default-settings.ignoredPaths": {
+          "type": "array",
+          "default": [],
+          "description": "Allows users to locally ignore synchronization on certain properties. Default: []. Example: [\"editor.rulers\"]",
+          "items": {
+            "type": "string",
+            "title": "settings property paths"
+          }
         }
       }
     }
@@ -58,6 +67,7 @@
   },
   "devDependencies": {
     "@types/glob": "8.1.0",
+    "@types/lodash": "^4.14.202",
     "@types/mocha": "10.0.6",
     "@types/node": "18.19.8",
     "@types/vscode": "1.63.0",
@@ -72,6 +82,7 @@
     "vscode-test": "1.6.1"
   },
   "dependencies": {
-    "jsonc-parser": "3.2.0"
+    "jsonc-parser": "3.2.0",
+    "lodash": "^4.17.21"
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { promisify } from "util";
 import * as vscode from "vscode";
 
 import { parse, ParseError } from "jsonc-parser";
+import { unset } from "lodash";
 
 const exists = promisify(fs.exists);
 const readFile = promisify(fs.readFile);
@@ -62,6 +63,14 @@ export function activate(context: vscode.ExtensionContext) {
             throw new Error(
               "Failed to parse settings.json. Please make sure it contains correct JSON content."
             );
+          }
+
+          const ignoredPaths: string[] = vscode.workspace
+            .getConfiguration("workspace-default-settings")
+            .get("ignoredPaths", []);
+
+          for (const path of ignoredPaths) {
+            unset(currentSettings, path);
           }
         }
         const defaultSettingsContent = await readFile(


### PR DESCRIPTION
This setting, when set on the local `settings.json` file allows the local user to ignore synchronization of certain paths in the configuration. This means that these paths simply won't be overwritten by default settings. We discussed that at https://github.com/dangmai/vscode-workspace-default-settings/issues/464#issuecomment-1898984659

This is very useful for teams where some members may decide to keep their own highly specific settings or accessibility preferences, while still benefiting from synchronizing all other settings.

An banal example of this can be `editor.rulers` which may be set to defaults defined in the lint configuration, but some individuals may want to disable or change it locally.

## Usage of lodash

While I'm not a fan of needlessly using additional npm modules, In this case lodash offers a perfect companion module and keeps the extension's code lightweight and simple. In fact `lodash/unset` supports some very advanced cases that were not at all the goal when I started writing this. For example: `foo.foo`, `foo[0]` etc.

According to the wisdom of the internet, by importing lodash as `import * as unset from "lodash/unset";` we manually tree-shake all unused stuff and only import this single file.

## How I tested this

Since the extension code has no tests, I haven't written any, but I've tested with the following configuration:
- `settings.default.json`
    ```json
    {
      "test.string": "overwritten",
      "teststringnodot": "overwritten",
      "test.object": {
        "foo": "overwritten",
        "bar": "overwritten"
      },
      "test.array": ["overwritten", "overwritten"]
    }
    ```
- `settings.default.json`
    ```json
    {
      "test.string": "local",
      "teststringnodot": "local",
      "test.object": {
        "foo": "local",
        "bar": "local"
      },
      "test.array": [ "local", "local" ],
      "workspace-default-settings.ignoredPaths": [
        "teststringnodot",
        "test.string",
        "test.object.foo",
        "test.array[0]"
      ]
    }
    ```
- Result: `settings.json`
    ```json
    {
      "test.string": "local",
      "teststringnodot": "local",
      "test.object": {
        "foo": "overwritten",
        "bar": "overwritten"
      },
      "test.array": [
        "overwritten",
        "overwritten"
      ],
      "workspace-default-settings.ignoredPaths": [
        "teststringnodot",
        "test.string",
        "test.object.foo",
        "test.array[0]"
      ]
    }
    ```

As you can see, the base usage with `teststringnodot` and `test.string` works just fine, while the deeper object and array notation unfortunately doesn't due to `Object.assign` not performing a deep merge.

I personally think this is completely fine as it is, and those advanced syntax cases are not going to be used. If someone ever raises the question and opens a bug report for that, with a legitimate use case, we could simply use `deepmerge` to perform a deep merge, although I would consider that a breaking change.