### PR TITLE
refactor(release): also publish to Open VSX

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,6 +13,10 @@ jobs:
         with:
           node-version: 16
       - run: yarn install --frozen-lockfile
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v2
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@v2
         with:


### PR DESCRIPTION
Updates to publish to Open VSX as well as the vscode marketplace. To make this work a maintainer will need to add the listed GHA secret, and I think also get set up in Open VSX with the extension namespace?

Relevant docs: https://github.com/HaaLeo/publish-vscode-extension?tab=readme-ov-file#open-vsx-registry

Closes https://github.com/dangmai/vscode-workspace-default-settings/issues/686